### PR TITLE
fixed the Dockerfile.staged

### DIFF
--- a/Dockerfile.staged
+++ b/Dockerfile.staged
@@ -39,3 +39,5 @@ EXPOSE 8080
 ENV path="." \
     name="dev" \
     ext="env"
+CMD [ "/app/main" ]
+ENTRYPOINT  ["/app/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,9 @@
 set -e 
 
 echo "executing database migration"
+
 source /app/dev.env
+
 /app/migrate -path /app/migrations -database "$DB_SOURCE" -verbose up
 
 echo "starting the app"


### PR DESCRIPTION
Added the cmd and entrypoint in the Dockerfile.staged 
I removed these two lines after writing the docker-compose file as I have mentioned cmd and entrypoint there, Here is a little catch that if we use docker-compose and give the cmd and entrypoint there, then the cmd and entrypoint in the  Dockerfile is ignored.